### PR TITLE
Minor bugfixes

### DIFF
--- a/VMSeal/Library/VM/StateObserver.swift
+++ b/VMSeal/Library/VM/StateObserver.swift
@@ -1,0 +1,36 @@
+//
+//  +---------------------------------------------------------+
+//  | Copyright (c) 2026 Axel H. Karlsson and contributors.   |
+//  |                                                         |
+//  | This file is licenced under the BSD 3-clause licence;   |
+//  | see the LICENSE file in the project's source directory. |
+//  +---------------------------------------------------------+
+//
+//  Delegate.swift
+//  VMSeal
+//
+//  Created by Axel H. Karlsson on 2026-03-31.
+//
+
+import Foundation
+import Virtualization
+
+extension VM {
+    /** Observer which ensures that `VZVirtualMachine.state` isn't stale. */
+    @Observable
+    class StateObserver {
+        var state: VZVirtualMachine.State = .stopped
+        
+        private var vm: VZVirtualMachine
+        private var observation: NSKeyValueObservation?
+        
+        init(vm: VZVirtualMachine) {
+            self.vm = vm
+            self.observation = nil
+            
+            self.observation = self.vm.observe(\.state, options: [.new]) { vm, change in
+                self.state = vm.state
+            }
+        }
+    }
+}

--- a/VMSeal/Library/VM/Storage.swift
+++ b/VMSeal/Library/VM/Storage.swift
@@ -75,6 +75,7 @@ extension VM {
             }
         }
         
+        /** Avoid calling this method directly instead of `VM.rename()`, since this method only renames its directory. */
         func rename(to newName: String) throws -> Void {
             try self.path.move(
                 to: Path(.Places.vms, newName.btoa())

--- a/VMSeal/Library/VM/VM.swift
+++ b/VMSeal/Library/VM/VM.swift
@@ -38,8 +38,10 @@ class VM: Identifiable {
     
     let cdrom: VM.CDROM
     
+    private var stateObserver: VM.StateObserver? = nil
+    
     var state: VZVirtualMachine.State {
-        self.vm?.state ?? .stopped
+        self.stateObserver?.state ?? .stopped
     }
     
     static func getDefaultDevices(diskSize: Double, storage: VM.Storage) throws -> [Device.Configurable] {
@@ -165,17 +167,26 @@ class VM: Identifiable {
                 configuration: self.configuration
             )
             
+            self.stateObserver = VM.StateObserver(vm: self.vm!)
+            
             try await self.vm?.start()
         } catch let e {
             throw UserFacingError(
-                message: "Something went wrong starting the box!\nDetails: \(e.localizedDescription)",
+                message: "Something went wrong starting the VM!\nDetails: \(e.localizedDescription)",
                 fatal: true
             )
         }
     }
     
-    func stop() throws {
-        try self.vm?.requestStop()
+    func stop() {
+        self.vm?.stop { error in
+            guard error != nil else {
+                // TODO: Handle errors!
+                return
+            }
+            
+            self.stateObserver = nil
+        }
     }
     
     func rename(to newName: String) throws {

--- a/VMSeal/UI/Dashboard/Detail.swift
+++ b/VMSeal/UI/Dashboard/Detail.swift
@@ -12,9 +12,24 @@
 //  Created by Axel H. Karlsson on 2026-03-23.
 //
 
-
 import SwiftUI
 import Virtualization
+
+private struct VMStopped: View {
+    var body: some View {
+        HStack {
+            Image(systemName: "pause.circle")
+            
+            Spacer()
+                .frame(width: 10)
+            
+            Text("Stopped")
+                .bold()
+        }
+        .font(.largeTitle)
+        .foregroundStyle(.white)
+    }
+}
 
 extension Dashboard {
     struct Detail {
@@ -46,15 +61,8 @@ extension Dashboard {
                             .id(selectedVM!.id) // setting ID prevents a bug where old artifacts show up on shutdown VMs.
                         
                         if selectedVM!.state == .stopped {
-                            // TODO: Refactor this
-                            HStack {
-                                Image(systemName: "pause.circle")
-                                Spacer()
-                                    .frame(width: 10)
-                                Heading(1, "Stopped")
-                            }.font(.largeTitle)
+                            VMStopped()
                         }
-
                     }
                 } else {
                     Text("Something went wrong displaying the VM...")


### PR DESCRIPTION
Fixes:
* `VM.state` wasn't reactive
* "VM Stopped" message colour was transparent; i.e. effectively invisible